### PR TITLE
Custom usage function

### DIFF
--- a/main.go
+++ b/main.go
@@ -24,11 +24,6 @@ var quietFlag = flag.Bool("quiet", false, "ignores non critical output")
 
 func main() {
 	flag.Parse()
-	config := LoadConfig()
-	if *forceFlag == true {
-		config.Delete()
-		config = LoadConfig()
-	}
 
 	// Check how many arguments are passed
 	if len(flag.Args()) == 0 {
@@ -41,7 +36,13 @@ func main() {
 		log.Fatalln(err)
 	}
 
-	// Get address
+	config := LoadConfig()
+	if *forceFlag == true {
+		config.Delete()
+		config = LoadConfig()
+	}
+
+	// Get addresses
 	address, err := getAddress(&config)
 	if err != nil {
 		log.Fatalln(err)

--- a/main.go
+++ b/main.go
@@ -23,11 +23,21 @@ var debugFlag = flag.Bool("debug", false, "increase verbosity")
 var quietFlag = flag.Bool("quiet", false, "ignores non critical output")
 
 func main() {
+	// Custom usage function
+	flag.Usage = func() {
+		fmt.Fprintf(os.Stderr,
+			"usage: %s [-debug] [-force] [-quiet] [-zip] file [file ...]\n",
+			os.Args[0])
+		flag.PrintDefaults()
+		os.Exit(2)
+	}
+
 	flag.Parse()
 
 	// Check how many arguments are passed
 	if len(flag.Args()) == 0 {
-		log.Fatalln("At least one argument is required")
+		fmt.Fprintln(os.Stderr, "At least one file must be provided")
+		flag.Usage()
 	}
 
 	// Get Content


### PR DESCRIPTION
- Creates a custom usage message
- If there are zero arguments print the usage message along with the error message
- Also moves the argument check before the check for the force flag, so the config isn't deleted when there are not a valid number of arguments

```
usage: qr-filetransfer [-debug] [-force] [-quiet] [-zip] file [file ...]
  -debug
    	increase verbosity
  -force
    	ignore saved configuration
  -quiet
    	ignores non critical output
  -zip
    	zip the contents to be transfered
```