### PR TITLE
Check if output dir not exists

### DIFF
--- a/cmd/receive.go
+++ b/cmd/receive.go
@@ -21,7 +21,9 @@ func receiveCmdFunc(command *cobra.Command, args []string) error {
 		return err
 	}
 	// Sets the output directory
-	srv.ReceiveTo(outputFlag)
+	if err := srv.ReceiveTo(outputFlag); err != nil {
+		return err
+	}
 	// Prints the URL to scan to screen
 	log.Print("Scan the following URL with a QR reader to start the file transfer:")
 	log.Print(srv.ReceiveURL)

--- a/server/server.go
+++ b/server/server.go
@@ -42,7 +42,11 @@ func (s *Server) ReceiveTo(dir string) error {
 		return err
 	}
 	// Check if the output dir exists
-	if dir, _ := os.Stat(output); dir == nil || !dir.IsDir() {
+	fileinfo, err := os.Stat(output)
+	if err != nil {
+		return err
+	}
+	if !fileinfo.IsDir() {
 		return fmt.Errorf("%s is not a valid directory", output)
 	}
 	s.outputDir = output

--- a/server/server.go
+++ b/server/server.go
@@ -42,7 +42,7 @@ func (s *Server) ReceiveTo(dir string) error {
 		return err
 	}
 	// Check if the output dir exists
-	if dir, _ := os.Stat(output); !dir.IsDir() {
+	if dir, _ := os.Stat(output); dir == nil || !dir.IsDir() {
 		return fmt.Errorf("%s is not a valid directory", output)
 	}
 	s.outputDir = output


### PR DESCRIPTION
where receive dir is not exist
`
qrcp receive --output=/abcd/
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x1410e68]

goroutine 1 [running]:
github.com/claudiodangelis/qrcp/server.(*Server).ReceiveTo(0xc00028c000, 0x7ffeefbffb5e, 0x6, 0x0, 0x0)
	/Users/heyong/gomod-workspace/my-qrcp/server/server.go:45 +0x78
github.com/claudiodangelis/qrcp/cmd.receiveCmdFunc(0x18ea6a0, 0xc000068290, 0x0, 0x1, 0x0, 0x0)
	/Users/heyong/gomod-workspace/my-qrcp/cmd/receive.go:24 +0x1c9
github.com/spf13/cobra.(*Command).execute(0x18ea6a0, 0xc000068280, 0x1, 0x1, 0x18ea6a0, 0xc000068280)
	/Users/heyong/go/pkg/mod/github.com/spf13/cobra@v1.0.0/command.go:842 +0x460
github.com/spf13/cobra.(*Command).ExecuteC(0x18ea400, 0xc0001b7f20, 0x103d0aa, 0x18a6120)
	/Users/heyong/go/pkg/mod/github.com/spf13/cobra@v1.0.0/command.go:950 +0x349
github.com/spf13/cobra.(*Command).Execute(...)
	/Users/heyong/go/pkg/mod/github.com/spf13/cobra@v1.0.0/command.go:887
github.com/claudiodangelis/qrcp/cmd.Execute(0x10076cf, 0xc000094058)
	/Users/heyong/gomod-workspace/my-qrcp/cmd/qrcp.go:45 +0x2d
main.main()
	/Users/heyong/gomod-workspace/my-qrcp/main.go:10 +0x26
`