### PR TITLE
Added config file flag

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -6,7 +6,7 @@ import (
 )
 
 func configCmdFunc(command *cobra.Command, args []string) error {
-	return config.Wizard()
+	return config.Wizard(configFileFlag)
 }
 
 var configCmd = &cobra.Command{

--- a/cmd/qrcp.go
+++ b/cmd/qrcp.go
@@ -1,6 +1,9 @@
 package cmd
 
 import (
+	"os/user"
+	"path/filepath"
+
 	"github.com/spf13/cobra"
 )
 
@@ -10,6 +13,7 @@ func init() {
 	rootCmd.AddCommand(configCmd)
 	rootCmd.AddCommand(versionCmd)
 	// Global command flags
+	rootCmd.PersistentFlags().StringVarP(&configFileFlag, "config-file", "c", defaultConfigPath(), "config file location")
 	rootCmd.PersistentFlags().BoolVarP(&quietFlag, "quiet", "q", false, "only print errors")
 	rootCmd.PersistentFlags().BoolVarP(&keepaliveFlag, "keep-alive", "k", false, "keep server alive after transferring")
 	rootCmd.PersistentFlags().BoolVarP(&listallinterfacesFlag, "list-all-interfaces", "l", false, "list all available interfaces when choosing the one to use")
@@ -22,7 +26,16 @@ func init() {
 	receiveCmd.PersistentFlags().StringVarP(&outputFlag, "output", "o", "", "output directory for receiving files")
 }
 
+func defaultConfigPath() string {
+	currentUser, err := user.Current()
+	if err != nil {
+		panic(err)
+	}
+	return filepath.Join(currentUser.HomeDir, ".qrcp.json")
+}
+
 // Flags
+var configFileFlag string
 var zipFlag bool
 var portFlag int
 var interfaceFlag string

--- a/cmd/receive.go
+++ b/cmd/receive.go
@@ -11,7 +11,7 @@ import (
 func receiveCmdFunc(command *cobra.Command, args []string) error {
 	log := logger.New(quietFlag)
 	// Load configuration
-	cfg, err := config.New(interfaceFlag, portFlag, pathFlag, fqdnFlag, keepaliveFlag, listallinterfacesFlag)
+	cfg, err := config.New(configFileFlag, interfaceFlag, portFlag, pathFlag, fqdnFlag, keepaliveFlag, listallinterfacesFlag)
 	if err != nil {
 		return err
 	}

--- a/cmd/send.go
+++ b/cmd/send.go
@@ -16,7 +16,7 @@ func sendCmdFunc(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	cfg, err := config.New(interfaceFlag, portFlag, pathFlag, fqdnFlag, keepaliveFlag, listallinterfacesFlag)
+	cfg, err := config.New(configFileFlag, interfaceFlag, portFlag, pathFlag, fqdnFlag, keepaliveFlag, listallinterfacesFlag)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Configuration file location can now be specified, though flag
--config/-c, and it is possible to have multiple configuration files.

Also did some slight refactoring. Config file module is now location agnostic, with file path being specified on method calls. Default file location locig pulled out to cmd, as this is the only place it is used. If it's preferable to have this somewhere else, I'll be happy to change that.

I've done some rough testing, both interactive config generation as well as file tranfer seems to be working fine on my local machine.

Ref #122, as well as homebrew/homebrew-core#54368.