### PR TITLE
Add support for HTTPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,19 @@ Pass the `--fqdn` (or `-d`) to use a fully qualified domain name instead of the 
 qrcp --fqdn example.com -i any -p 8080 MyRemoteDocument.pdf
 ```
 
+### HTTPS
+
+**qrcp** supports secure file transfers with HTTPS. To enable secure transfers you need a TLS certificate and the associated key.
+
+You can choose the path to the TLS certificate and keys from the `qrcp config` wizard, or, if you want, you can pass the `--tls-cert` and `--tls-key`:
+
+```sh
+qrcp --tls-cert /path/to/cert.pem --tls-key /path/to/cert.key MyDocument
+```
+
+A `--secure` flag is available too, you can use it to override the default value.
+
+
 ### Open in browser
 
 If you need a QR to be printed outside your terminal, you can pass the `--browser` flag. With this flag, `qrcp` will still print the QR code to the terminal, but it will also open a new window of your default browser to show the QR code.

--- a/cmd/qrcp.go
+++ b/cmd/qrcp.go
@@ -20,6 +20,7 @@ func init() {
 	rootCmd.PersistentFlags().BoolVarP(&zipFlag, "zip", "z", false, "zip content before transferring")
 	rootCmd.PersistentFlags().StringVarP(&configFlag, "config", "c", "", "path to the config file, defaults to $HOME/.qrcp")
 	rootCmd.PersistentFlags().BoolVarP(&browserFlag, "browser", "b", false, "display the QR code in a browser window")
+	rootCmd.PersistentFlags().BoolVarP(&secureFlag, "secure", "s", false, "use https connection")
 	// Receive command flags
 	receiveCmd.PersistentFlags().StringVarP(&outputFlag, "output", "o", "", "output directory for receiving files")
 }
@@ -36,6 +37,7 @@ var pathFlag string
 var listallinterfacesFlag bool
 var configFlag string
 var browserFlag bool
+var secureFlag bool
 
 // The root command (`qrcp`) is like a shortcut of the `send` command
 var rootCmd = &cobra.Command{

--- a/cmd/qrcp.go
+++ b/cmd/qrcp.go
@@ -21,6 +21,8 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(&configFlag, "config", "c", "", "path to the config file, defaults to $HOME/.qrcp")
 	rootCmd.PersistentFlags().BoolVarP(&browserFlag, "browser", "b", false, "display the QR code in a browser window")
 	rootCmd.PersistentFlags().BoolVarP(&secureFlag, "secure", "s", false, "use https connection")
+	rootCmd.PersistentFlags().StringVar(&tlscertFlag, "tls-cert", "", "path to TLS certificate to use with HTTPS")
+	rootCmd.PersistentFlags().StringVar(&tlskeyFlag, "tls-key", "", "path to TLS private key to use with HTTPS")
 	// Receive command flags
 	receiveCmd.PersistentFlags().StringVarP(&outputFlag, "output", "o", "", "output directory for receiving files")
 }
@@ -38,6 +40,8 @@ var listallinterfacesFlag bool
 var configFlag string
 var browserFlag bool
 var secureFlag bool
+var tlscertFlag string
+var tlskeyFlag string
 
 // The root command (`qrcp`) is like a shortcut of the `send` command
 var rootCmd = &cobra.Command{

--- a/cmd/receive.go
+++ b/cmd/receive.go
@@ -19,6 +19,8 @@ func receiveCmdFunc(command *cobra.Command, args []string) error {
 		KeepAlive:         keepaliveFlag,
 		ListAllInterfaces: listallinterfacesFlag,
 		Secure:            secureFlag,
+		TLSCert:           tlscertFlag,
+		TLSKey:            tlskeyFlag,
 	}
 	cfg, err := config.New(configFlag, configOptions)
 	if err != nil {

--- a/cmd/receive.go
+++ b/cmd/receive.go
@@ -18,6 +18,7 @@ func receiveCmdFunc(command *cobra.Command, args []string) error {
 		FQDN:              fqdnFlag,
 		KeepAlive:         keepaliveFlag,
 		ListAllInterfaces: listallinterfacesFlag,
+		Secure:            secureFlag,
 	}
 	cfg, err := config.New(configFlag, configOptions)
 	if err != nil {

--- a/cmd/send.go
+++ b/cmd/send.go
@@ -25,6 +25,8 @@ func sendCmdFunc(command *cobra.Command, args []string) error {
 		KeepAlive:         keepaliveFlag,
 		ListAllInterfaces: listallinterfacesFlag,
 		Secure:            secureFlag,
+		TLSCert:           tlscertFlag,
+		TLSKey:            tlskeyFlag,
 	}
 	cfg, err := config.New(configFlag, configOptions)
 	if err != nil {

--- a/cmd/send.go
+++ b/cmd/send.go
@@ -24,6 +24,7 @@ func sendCmdFunc(command *cobra.Command, args []string) error {
 		FQDN:              fqdnFlag,
 		KeepAlive:         keepaliveFlag,
 		ListAllInterfaces: listallinterfacesFlag,
+		Secure:            secureFlag,
 	}
 	cfg, err := config.New(configFlag, configOptions)
 	if err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -23,6 +23,8 @@ type Config struct {
 	KeepAlive bool   `json:"keepAlive"`
 	Path      string `json:"path"`
 	Secure    bool   `json:"secure"`
+	TLSKey    string `json:"tls-key"`
+	TLSCert   string `json:"tls-cert"`
 }
 
 var configFile string
@@ -36,6 +38,7 @@ type Options struct {
 	KeepAlive         bool
 	Interactive       bool
 	ListAllInterfaces bool
+	Secure            bool
 }
 
 func chooseInterface(opts Options) (string, error) {
@@ -266,5 +269,9 @@ func New(path string, opts Options) (Config, error) {
 	if opts.Path != "" {
 		cfg.Path = opts.Path
 	}
+	cfg.Secure = opts.Secure
+	cfg.TLSCert = ""
+	cfg.TLSKey = ""
+	fmt.Println(cfg.Secure)
 	return cfg, nil
 }

--- a/config/config.go
+++ b/config/config.go
@@ -22,6 +22,7 @@ type Config struct {
 	Port      int    `json:"port"`
 	KeepAlive bool   `json:"keepAlive"`
 	Path      string `json:"path"`
+	Secure    bool   `json:"secure"`
 }
 
 var configFile string

--- a/config/config.go
+++ b/config/config.go
@@ -40,6 +40,8 @@ type Options struct {
 	Interactive       bool
 	ListAllInterfaces bool
 	Secure            bool
+	TLSCert           string
+	TLSKey            string
 }
 
 func chooseInterface(opts Options) (string, error) {
@@ -330,8 +332,8 @@ func New(path string, opts Options) (Config, error) {
 		cfg.Path = opts.Path
 	}
 	cfg.Secure = opts.Secure
-	cfg.TLSCert = ""
-	cfg.TLSKey = ""
+	cfg.TLSCert = opts.TLSCert
+	cfg.TLSKey = opts.TLSKey
 	fmt.Println(cfg.Secure)
 	return cfg, nil
 }

--- a/server/server.go
+++ b/server/server.go
@@ -304,19 +304,15 @@ func New(cfg *config.Config) (*Server, error) {
 		}
 		app.stopChannel <- true
 	}()
-	// Receive handler (receives file from caller)
 	go func() {
-		// Check if TLS or not
 		netListener := tcpKeepAliveListener{listener.(*net.TCPListener)}
 		if cfg.Secure {
-			// TLS
 			if err := httpserver.ServeTLS(netListener, cfg.TLSCert, cfg.TLSKey); err != http.ErrServerClosed {
-				log.Fatalln(err)
+				log.Fatalln("error starting the server:", err)
 			}
 		} else {
-			// No TLD
 			if err := httpserver.Serve(netListener); err != http.ErrServerClosed {
-				log.Fatalln(err)
+				log.Fatalln("error starting the server", err)
 			}
 		}
 	}()
@@ -335,7 +331,7 @@ func openBrowser(url string) {
 	case "darwin":
 		err = exec.Command("open", url).Start()
 	default:
-		err = fmt.Errorf("Failed to open browser on platform: %s", runtime.GOOS)
+		err = fmt.Errorf("failed to open browser on platform: %s", runtime.GOOS)
 	}
 	if err != nil {
 		log.Fatal(err)

--- a/server/server.go
+++ b/server/server.go
@@ -127,10 +127,11 @@ func New(cfg *config.Config) (*Server, error) {
 		hostname = fmt.Sprintf("%s:%d", cfg.FQDN, port)
 	}
 	// Set URLs
-	app.BaseURL = fmt.Sprintf("http://%s", hostname)
+	protocol := "http"
 	if cfg.Secure {
-		app.BaseURL = fmt.Sprintf("https://%s", hostname)
+		protocol = "https"
 	}
+	app.BaseURL = fmt.Sprintf("%s://%s", protocol, hostname)
 	app.SendURL = fmt.Sprintf("%s/send/%s",
 		app.BaseURL, path)
 	app.ReceiveURL = fmt.Sprintf("%s/receive/%s",

--- a/util/util.go
+++ b/util/util.go
@@ -8,12 +8,31 @@ import (
 	"io/ioutil"
 	"net"
 	"os"
+	"os/user"
+	"path/filepath"
 	"regexp"
+	"runtime"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/jhoonb/archivex"
 )
+
+// Expand tilde in paths
+func Expand(input string) string {
+	if runtime.GOOS == "windows" {
+		return input
+	}
+	usr, _ := user.Current()
+	dir := usr.HomeDir
+	if input == "~" {
+		input = dir
+	} else if strings.HasPrefix(input, "~/") {
+		input = filepath.Join(dir, input[2:])
+	}
+	return input
+}
 
 // ZipFiles and return the resulting zip's filename
 func ZipFiles(files []string) (string, error) {


### PR DESCRIPTION
This PR brings the support for HTTPS. Specifications:


- [x] cert and key can be passed to the command line like `--tls-cert`, `--tls-key`
- [x] if passed to the command line, those value override defaults
- [x] in `qrcp config` user can choose to default to secure
- [x] the `--secure` flag overrides default
- [x] `qrcp` will not generate certificates

EDIT:
I removed the following item from the specs, because I don't really feel the need of it:
_- default cert and key can be stored to a configurable directory which defaults to `$HOME/.qrcp/tls`_
