### PR TITLE
¨Optimised¨ some Linux installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Download the latest Linux .tar.gz archive from the [Releases](https://github.com
 
 ```sh
 # Extract the archive
-tar xf qrcp_*.tar.gz
+tar xf qrcp*
 # Copy the binary
 sudo mv qrcp /usr/local/bin
 # Set execution permissions

--- a/README.md
+++ b/README.md
@@ -42,11 +42,11 @@ _Note: it requires go 1.8_
 
 ## Linux
 
-Download the latest Linux .tar.gz archive from the [Releases](https://github.com/claudiodangelis/qrcp/releases) page, extract it, move the binary to the proper directory, then set execution permissions.
+Download the latest Linux .tar.gz archive from the [Releases](https://github.com/claudiodangelis/qrcp/releases/latest) page, extract it, move the binary to the proper directory, then set execution permissions.
 
 ```sh
 # Extract the archive
-tar xf qrcp_0.5.0_linux_x86_64.tar.gz
+tar xf qrcp_*.tar.gz
 # Copy the binary
 sudo mv qrcp /usr/local/bin
 # Set execution permissions


### PR DESCRIPTION
```
pm@vix ~ $ ls
bin  Bureau  Documents  go  Images  Modèles  Musique  Public  qrcp_0.7.0_linux_arm64.tar.gz  solus-extra-repo  Téléchargements  Vidéos
pm@vix ~ $ tar xf qrcp_0.5.0_linux_x86_64.tar.gz
tar: qrcp_0.5.0_linux_x86_64.tar.gz : open impossible: Aucun fichier ou dossier de ce type
tar: Error is not recoverable: exiting now
pm@vix ~ $ tar xf qrcp*
pm@vix ~ $ ls
bin  Bureau  Documents  go  Images  LICENSE  Modèles  Musique  Public  qrcp  qrcp_0.7.0_linux_arm64.tar.gz  README.md  solus-extra-repo  Téléchargements  Vidéos
pm@vix ~ $ 
```

I’ve firstly replaced the release link, to always point to the latest release, as documented in the release GitHub doc : https://docs.github.com/en/enterprise-server@2.22/github/administering-a-repository/linking-to-releases  
I’ve also changed the tar extraction command, to extract the downloaded qrcp archive, regardless of the chosen version.