### PR TITLE
Add default output directory for "receive" command

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,7 @@ qrcp --tls-cert /path/to/cert.pem --tls-key /path/to/cert.key MyDocument
 
 A `--secure` flag is available too, you can use it to override the default value.
 
+### Default output directory
 
 ### Open in browser
 


### PR DESCRIPTION
This PR adds the ability to define a default output directory for received files.
The default directory is overridden by the `-o/--output` flag.