### PR TITLE
Add hostport to use qrcp in local server with reverse proxy

### DIFF
--- a/cmd/qrcp.go
+++ b/cmd/qrcp.go
@@ -18,6 +18,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&pathFlag, "path", "", "path to use. Defaults to a random string")
 	rootCmd.PersistentFlags().StringVarP(&interfaceFlag, "interface", "i", "", "network interface to use for the server")
 	rootCmd.PersistentFlags().StringVarP(&fqdnFlag, "fqdn", "d", "", "fully-qualified domain name to use for the resulting URLs")
+	rootCmd.PersistentFlags().StringVarP(&hostportFlag, "hostport", "D", "", "host and port to accept really FQDN")
 	rootCmd.PersistentFlags().BoolVarP(&zipFlag, "zip", "z", false, "zip content before transferring")
 	rootCmd.PersistentFlags().StringVarP(&configFlag, "config", "c", "", "path to the config file, defaults to $HOME/.qrcp")
 	rootCmd.PersistentFlags().BoolVarP(&browserFlag, "browser", "b", false, "display the QR code in a browser window")
@@ -36,6 +37,7 @@ var outputFlag string
 var keepaliveFlag bool
 var quietFlag bool
 var fqdnFlag string
+var hostportFlag string
 var pathFlag string
 var listallinterfacesFlag bool
 var configFlag string

--- a/cmd/receive.go
+++ b/cmd/receive.go
@@ -16,6 +16,7 @@ func receiveCmdFunc(command *cobra.Command, args []string) error {
 		Port:              portFlag,
 		Path:              pathFlag,
 		FQDN:              fqdnFlag,
+		Hostport:          hostportFlag,
 		KeepAlive:         keepaliveFlag,
 		ListAllInterfaces: listallinterfacesFlag,
 		Secure:            secureFlag,

--- a/cmd/send.go
+++ b/cmd/send.go
@@ -22,6 +22,7 @@ func sendCmdFunc(command *cobra.Command, args []string) error {
 		Port:              portFlag,
 		Path:              pathFlag,
 		FQDN:              fqdnFlag,
+		Hostport:          hostportFlag,
 		KeepAlive:         keepaliveFlag,
 		ListAllInterfaces: listallinterfacesFlag,
 		Secure:            secureFlag,

--- a/config/config.go
+++ b/config/config.go
@@ -18,6 +18,7 @@ import (
 // Config of qrcp
 type Config struct {
 	FQDN      string `json:"fqdn"`
+	Hostport  string `json:"hostport"`
 	Interface string `json:"interface"`
 	Port      int    `json:"port"`
 	KeepAlive bool   `json:"keepAlive"`
@@ -35,6 +36,7 @@ type Options struct {
 	Port              int
 	Path              string
 	FQDN              string
+	Hostport          string
 	KeepAlive         bool
 	Interactive       bool
 	ListAllInterfaces bool
@@ -163,6 +165,21 @@ func Wizard(path string, listAllInterfaces bool) error {
 		if port, err := strconv.ParseUint(promptPortResultString, 10, 16); err == nil {
 			cfg.Port = int(port)
 		}
+	}
+
+	validateHostport := func(input string) error {
+		if input != "" && govalidator.IsDialString(input) == false {
+			return errors.New("invalid host and port")
+		}
+		return nil
+	}
+	promptHostport := promptui.Prompt{
+		Validate: validateHostport,
+		Label:    "Choose replace host and port",
+		Default:  "",
+	}
+	if promptHostportResultString, err := promptHostport.Run(); err == nil {
+		cfg.Hostport = promptHostportResultString
 	}
 
 	// Ask for path

--- a/server/server.go
+++ b/server/server.go
@@ -123,7 +123,9 @@ func New(cfg *config.Config) (*Server, error) {
 		hostname = fmt.Sprintf("%s:%d", extIP.String(), port)
 	}
 	// Use a fully-qualified domain name if set
-	if cfg.FQDN != "" {
+	if cfg.Hostport != "" {
+		hostname = cfg.Hostport
+	} else if cfg.FQDN != "" {
 		hostname = fmt.Sprintf("%s:%d", cfg.FQDN, port)
 	}
 	// Set URLs


### PR DESCRIPTION
Added hostport option to display really acceptable host:port via reverse proxy.

Fixes #169

If you think that FQDN is that and hostport should be passed to listen instead, please let me known.
