### PR TITLE
Add Homebrew installation method to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,14 @@ sudo chmod +x /usr/local/bin/qrcp
 # Confirm it's working:
 qrcp --help
 ```
+
+### Homebrew
+
+If you use [Homebrew](https://brew.sh) for package management on macOS, you can install qrcp with the following one-liner:
+
+```
+brew install qrcp
+```
     
 # Usage
 


### PR DESCRIPTION
Updating readme to advertise the inclusion of `qrcp` in Homebrew core tap (https://github.com/Homebrew/homebrew-core/pull/54368 by @zub, in response to #112) 🎉  