### PR TITLE
Allow for setting port through environment variable

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -358,6 +358,18 @@ func New(path string, opts Options) (Config, error) {
 			return cfg, errors.New("invalid value for port")
 		}
 		cfg.Port = opts.Port
+	} else {
+		val, ok := os.LookupEnv("QRCP_PORT")
+		if ok {
+			envPort, err := strconv.Atoi(val)
+			if err != nil {
+				return cfg, errors.New("could not parse port from environment variable")
+			}
+			if envPort > 65535 {
+				return cfg, errors.New("invalid value for port")
+			}
+			cfg.Port = envPort
+		}
 	}
 	if opts.KeepAlive {
 		cfg.KeepAlive = true


### PR DESCRIPTION
Gives users the option to set the port through a `QRCP_PORT` environment variable. Allows for easier scripting and usage with firewalls. `QRCP_PORT` is only used if there is no flag or configuration specified (lowest priority) which allows for flexibility even when the environment variable has been set, for example, in a shell profile.

## Examples

### Setting port via variable
```console
$ QRCP_PORT=42069 ./qrcp main.go
Scan the following URL with a QR reader to start the file transfer, press CTRL+C or "q" to exit:
http://192.168.1.131:42069/send/7v6k
```

### Port override
```console
$ QRCP_PORT=42069 ./qrcp main.go -p 65511
Scan the following URL with a QR reader to start the file transfer, press CTRL+C or "q" to exit:
http://192.168.1.131:65511/send/8qca
```

### Erroneous variable 1
```console
$ QRCP_PORT=hello ./qrcp main.go
Error: could not parse port from environment variable
Run `qrcp help` for help.
```

### Erroneous variable 2
```console
$ QRCP_PORT=65536 ./qrcp main.go
Error: invalid value for port
Run `qrcp help` for help.
```