### PR TITLE
Extract base from multipart

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -241,7 +241,7 @@ func New(cfg *config.Config) (*Server, error) {
 					continue
 				}
 				// Prepare the destination
-				fileName := getFileName(part.FileName(), filenames)
+				fileName := getFileName(filepath.Base(part.FileName()), filenames)
 				out, err := os.Create(filepath.Join(app.outputDir, fileName))
 				if err != nil {
 					// Output to server


### PR DESCRIPTION
Related to: #223 

This was apparently an issue on the `mime/multipart` package of Go itself, which has been fixed 10 months ago, a few weeks after the latest release of qrcp.

Links:
- https://go-review.googlesource.com/c/go/+/313809
- https://github.com/golang/go/commit/784ef4c53135644d70f3476a4bd90010b9acff66 

