### PR TITLE
Updated instructions to install development version

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ _Note: it requires go 1.8_
 
     go get github.com/claudiodangelis/qrcp
 
+If using go 1.18 or higher,
+
+    go install github.com/claudiodangelis/qrcp@latest
+
 ## Linux
 
 Download the latest Linux .tar.gz archive from the [Releases](https://github.com/claudiodangelis/qrcp/releases) page, extract it, move the binary to the proper directory, then set execution permissions.

--- a/README.md
+++ b/README.md
@@ -104,6 +104,13 @@ If you use [Scoop](https://scoop.sh/) for package management on Windows, you can
 ```
 scoop install qrcp
 ```
+### Chocolatey
+
+If you use [Chocolatey](https://community.chocolatey.org/packages/qrcp) for package management on Windows, you can install qrcp with the following one-liner:
+
+```
+choco install qrcp
+```
 
 ## MacOS
 


### PR DESCRIPTION
Starting Go 1.18, go get no longer builds packages.  go install must be used to install a module.