### PR TITLE
Implement bind argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,14 +204,15 @@ To configure `qrcp` you can create a configuration file inside `$XDG_CONFIG_HOME
 | Key         | Type    | Notes                                                                                                                                                                                  |
 |-------------|---------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `interface` | String  | This value is automatically discovered during the first launch of `qrcp`, you can set it to override the default. You can use the `any` interface to bind the web server to `0.0.0.0`. |
+| `bind`      | String  | This value is used by qrcp to bind the web server to. Note: if this value is set, the `interface` parameter is ignored.                                                                |
 | `port`      | Integer | When this value is not set, `qrcp` will pick a random port at any launch.                                                                                                              |
-| `path` | String | When this value is not set, `qrcp` will add a random string at the end of URL. |
-| `output` | String | Default directory to receive files to. If empty, the current working directory is used. |
-| `fqdn` | String | When this value is set, `qrcp` will use it to replace the IP address in the generated URL.  |
-| `keepAlive` | Bool | Controls whether `qrcp` should quit after transferring the file. Defaults to `false`. |
-| `secure` | Bool | Controls whether `qrcp` should use HTTPS instead of HTTP. Defaults to `false` |
-| `tls-cert` | String | Path to the TLS certificate. It's only used when `secure: true`. |
-| `tls-key` | String | Path to the TLS key. It's only used when `secure: true`. |
+| `path`      | String  | When this value is not set, `qrcp` will add a random string at the end of URL.                                                                                                         |
+| `output`    | String  | Default directory to receive files to. If empty, the current working directory is used.                                                                                                |
+| `fqdn`      | String  | When this value is set, `qrcp` will use it to replace the IP address in the generated URL.                                                                                             |
+| `keepAlive` | Bool    | Controls whether `qrcp` should quit after transferring the file. Defaults to `false`.                                                                                                  |
+| `secure`    | Bool    | Controls whether `qrcp` should use HTTPS instead of HTTP. Defaults to `false`                                                                                                          |
+| `tls-cert`  | String  | Path to the TLS certificate. It's only used when `secure: true`.                                                                                                                       |
+| `tls-key`   | String  | Path to the TLS key. It's only used when `secure: true`.                                                                                                                               |
 
 
 All the configuration parameters can be controlled via environment variables prefixed with `QRCP_`, for example:
@@ -281,6 +282,13 @@ This is useful when you want to transfer files from your Amazon EC2, Digital Oce
 qrcp -i any MyDocument.pdf
 ```
 
+### Bind
+
+Alternatively to choosing the interface, you can directly specify the address you want `qrcp` to bind the webserver to.
+
+```sh
+qrcp --bind 10.20.30.40 MyDocument.pdf
+```
 
 ### URL
 

--- a/application/application.go
+++ b/application/application.go
@@ -7,6 +7,7 @@ type Flags struct {
 	Port              int
 	Path              string
 	Interface         string
+	Bind              string
 	FQDN              string
 	Zip               bool
 	Config            string

--- a/cmd/qrcp.go
+++ b/cmd/qrcp.go
@@ -22,6 +22,7 @@ func init() {
 	rootCmd.PersistentFlags().IntVarP(&app.Flags.Port, "port", "p", 0, "port to use for the server")
 	rootCmd.PersistentFlags().StringVar(&app.Flags.Path, "path", "", "path to use. Defaults to a random string")
 	rootCmd.PersistentFlags().StringVarP(&app.Flags.Interface, "interface", "i", "", "network interface to use for the server")
+	rootCmd.PersistentFlags().StringVar(&app.Flags.Bind, "bind", "", "address to bind the web server to")
 	rootCmd.PersistentFlags().StringVarP(&app.Flags.FQDN, "fqdn", "d", "", "fully-qualified domain name to use for the resulting URLs")
 	rootCmd.PersistentFlags().BoolVarP(&app.Flags.Zip, "zip", "z", false, "zip content before transferring")
 	rootCmd.PersistentFlags().StringVarP(&app.Flags.Config, "config", "c", "", "path to the config file, defaults to $XDG_CONFIG_HOME/qrcp/config.json")

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -86,6 +86,7 @@ func TestNew(t *testing.T) {
 				Interface: "wlo1",
 				Port:      18080,
 				KeepAlive: false,
+				Bind:      "10.20.30.40",
 				Path:      "random",
 				Secure:    false,
 				TlsKey:    "/path/to/key",
@@ -106,6 +107,7 @@ func TestNew(t *testing.T) {
 			Config{
 				Interface: "wlo1",
 				Port:      99999,
+				Bind:      "10.20.30.40",
 				KeepAlive: false,
 				Path:      "random",
 				Secure:    false,

--- a/config/testdata/full.yml
+++ b/config/testdata/full.yml
@@ -1,5 +1,6 @@
 interface: wlo1
 port: 18080
+bind: '10.20.30.40'
 keepAlive: false
 path: random
 secure: false

--- a/server/server.go
+++ b/server/server.go
@@ -102,10 +102,14 @@ func (s Server) Shutdown() {
 func New(cfg *config.Config) (*Server, error) {
 
 	app := &Server{}
-	// Get the address of the configured interface to bind the server to
+	// Get the address of the configured interface to bind the server to.
+	// If `bind` configuration parameter has been configured, it takes precedence
 	bind, err := util.GetInterfaceAddress(cfg.Interface)
 	if err != nil {
 		return &Server{}, err
+	}
+	if cfg.Bind != "" {
+		bind = cfg.Bind
 	}
 	// Create a listener. If `port: 0`, a random one is chosen
 	listener, err := net.Listen("tcp", fmt.Sprintf("%s:%d", bind, cfg.Port))


### PR DESCRIPTION
This PR adds the `bind` configuration parameter to set the bind address to listen to.
The `bind` parameter overrides the address of the `interface` parameter.

Configuration file:
```yaml
bind: 10.20.30.40
```

Command line:
```sh
qrcp --bind 10.20.30.40 /some/file
```

To get more context about this feature, refer to the issue: #264 .