### PR TITLE
Fix default text filename not valid on windows

### DIFF
--- a/pages/pages.go
+++ b/pages/pages.go
@@ -204,7 +204,7 @@ var Upload = `
             var textCheckbox = document.getElementById('check-send-text')
 
             if ((titleInput.value || textInput.value) && textCheckbox.checked) {
-                var currentDate = new Date().toJSON().slice(0,19).replace(/[-T]/g,'_')
+                var currentDate = new Date().toJSON().slice(0,19).replace(/[-T:]/g,'_')
                 // If the user didn't specify a file name, use 'qrcp-text-file-${currentDate}'
                 var filename = titleInput.value || ("qrcp-text-file-" + currentDate)
                 var blob = new Blob([textInput.value + '\n'], { type: "text/plain" })


### PR DESCRIPTION
`:` is not allowed in windows filename