### PR TITLE
Fixing deleting temp files and incorrect zip file

### DIFF
--- a/application/application.go
+++ b/application/application.go
@@ -16,7 +16,7 @@ type Flags struct {
 	TlsCert           string
 	TlsKey            string
 	Output            string
-	Reversed           bool
+	Reversed          bool
 }
 
 type App struct {

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/asaskevich/govalidator v0.0.0-20200108200545-475eaeb16496
 	github.com/eiannone/keyboard v0.0.0-20200508000154-caf4b762e807
 	github.com/glendc/go-external-ip v0.1.0
+	github.com/jhoonb/archivex v0.0.0-20180718040744-0488e4ce1681
 	github.com/manifoldco/promptui v0.9.0
 	github.com/mattn/go-runewidth v0.0.9 // indirect
 	github.com/skip2/go-qrcode v0.0.0-20191027152451-9434209cb086

--- a/go.sum
+++ b/go.sum
@@ -1430,6 +1430,8 @@ github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/jhoonb/archivex v0.0.0-20180718040744-0488e4ce1681 h1:EiEjLram6Y0WXygV4WyzKmTr3XaR4CD3tvjdTrsk3cU=
+github.com/jhoonb/archivex v0.0.0-20180718040744-0488e4ce1681/go.mod h1:GN1Mg/uXQ6qwXA0HypnUO3xlcQJS9/y68EsHNeuuRa4=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.9/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=

--- a/util/util.go
+++ b/util/util.go
@@ -33,8 +33,6 @@ func Expand(input string) string {
 	return input
 }
 
-
-
 // ZipFiles and return the resulting zip's filename
 func ZipFiles(files []string) (string, error) {
 	zip := new(archivex.ZipFile)
@@ -46,11 +44,11 @@ func ZipFiles(files []string) (string, error) {
 	if err := os.Rename(tmpfile.Name(), tmpfile.Name()+".zip"); err != nil {
 		return "", err
 	}
-	tmpfile,err = os.OpenFile(tmpfile.Name()+".zip", os.O_RDWR, 0644)
+	tmpfile, err = os.OpenFile(tmpfile.Name()+".zip", os.O_RDWR, 0644)
 	if err != nil {
 		return "", err
 	}
-	if err := zip.CreateWriter(tmpfile.Name(),tmpfile); err != nil {
+	if err := zip.CreateWriter(tmpfile.Name(), tmpfile); err != nil {
 		return "", err
 	}
 
@@ -78,7 +76,7 @@ func ZipFiles(files []string) (string, error) {
 	if err := zip.Writer.Close(); err != nil {
 		return "", err
 	}
-	if err:= tmpfile.Close(); err != nil {
+	if err := tmpfile.Close(); err != nil {
 		return "", err
 	}
 


### PR DESCRIPTION
This could fix the issue with the incorrect zip files (#317) and the delete of the temporary zip files in Windows (#277).

To fix the incorrect zip compression i reuse the archivex library (like it  was done at the beginning) but for fixing the delete of the temporary zip files in Windows, i use the "CreateWriter" function in order to close, at the end of function, the writer and the file.
