### PR TITLE
fix: Add UTF-8 filename* in Content-Disposition

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -219,8 +220,10 @@ func New(cfg *config.Config) (*Server, error) {
 			// Remove connection from the waitgroup when done
 			defer waitgroup.Done()
 		}
-		w.Header().Set("Content-Disposition", "attachment; filename="+
-			app.payload.Filename)
+		w.Header().Set("Content-Disposition", "attachment; filename=\""+
+			app.payload.Filename+
+			"\"; filename*=UTF-8''"+
+			url.QueryEscape(app.payload.Filename))
 		http.ServeFile(w, r, app.payload.Path)
 	})
 	// Upload handler (serves the upload page)


### PR DESCRIPTION
Fixes #331
Relates-to: #253

### Result of `qrcp send 啊.txt`

Before:

```
Content-Disposition: "attachment; filename=\xe5\x95\x8a.txt"
```

After:

```
Content-Disposition: "attachment; filename=\"\xe5\x95\x8a.txt\"; filename*=UTF-8''%E5%95%8A.txt"
```