### PR TITLE
Fix link when external IP is IPv6

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -134,7 +134,13 @@ func New(cfg *config.Config) (*Server, error) {
 		if err != nil {
 			panic(err)
 		}
-		hostname = fmt.Sprintf("%s:%d", extIP.String(), port)
+		extIPString := extIP.String()
+		fmtstring := "%s:%d"
+		if strings.Count(extIPString, ":") >= 2 {
+			// IPv6 address, wrap it in [] to add a port
+			fmtstring = "[%s]:%d"
+		}
+		hostname = fmt.Sprintf(fmtstring, extIPString, port)
 	}
 	// Use a fully-qualified domain name if set
 	if cfg.FQDN != "" {


### PR DESCRIPTION
The external IP module can return an IPv6 address, in which case the method to append a port is to wrap it in square brackets before appending the `:%d` port string.

Unfortunately Go's IP module does not have a great way to determine whether an address is an IPv6 address, so fall back to counting the number of colons in the result as suggested in https://stackoverflow.com/a/48519490.