### PR TITLE
Print messages to stderr when output is piped

### DIFF
--- a/application/application.go
+++ b/application/application.go
@@ -16,6 +16,7 @@ type Flags struct {
 	TlsCert           string
 	TlsKey            string
 	Output            string
+	FileName          string
 	Reversed          bool
 }
 

--- a/application/application.go
+++ b/application/application.go
@@ -15,7 +15,7 @@ type Flags struct {
 	Secure            bool
 	TlsCert           string
 	TlsKey            string
-	Output            string
+	OutputDir         string
 	FileName          string
 	Reversed          bool
 }

--- a/cmd/qrcp.go
+++ b/cmd/qrcp.go
@@ -32,7 +32,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&app.Flags.TlsKey, "tls-key", "", "path to TLS private key to use with HTTPS")
 	rootCmd.PersistentFlags().BoolVarP(&app.Flags.Reversed, "reversed", "r", false, "Reverse QR code (black text on white background)")
 	// Receive command flags
-	receiveCmd.PersistentFlags().StringVarP(&app.Flags.Output, "output-dir", "o", "", "output directory for receiving files")
+	receiveCmd.PersistentFlags().StringVarP(&app.Flags.OutputDir, "output-dir", "o", "", "output directory for receiving files")
 	receiveCmd.PersistentFlags().StringVarP(&app.Flags.FileName, "file", "f", "", "file name for the saved file. Use - to output to stdout instead")
 }
 

--- a/cmd/qrcp.go
+++ b/cmd/qrcp.go
@@ -32,7 +32,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&app.Flags.TlsKey, "tls-key", "", "path to TLS private key to use with HTTPS")
 	rootCmd.PersistentFlags().BoolVarP(&app.Flags.Reversed, "reversed", "r", false, "Reverse QR code (black text on white background)")
 	// Receive command flags
-	receiveCmd.PersistentFlags().StringVarP(&app.Flags.Output, "output", "o", "", "output directory for receiving files")
+	receiveCmd.PersistentFlags().StringVarP(&app.Flags.Output, "output-dir", "o", "", "output directory for receiving files")
 }
 
 // The root command (`qrcp`) is like a shortcut of the `send` command

--- a/cmd/qrcp.go
+++ b/cmd/qrcp.go
@@ -33,6 +33,7 @@ func init() {
 	rootCmd.PersistentFlags().BoolVarP(&app.Flags.Reversed, "reversed", "r", false, "Reverse QR code (black text on white background)")
 	// Receive command flags
 	receiveCmd.PersistentFlags().StringVarP(&app.Flags.Output, "output-dir", "o", "", "output directory for receiving files")
+	receiveCmd.PersistentFlags().StringVarP(&app.Flags.FileName, "file", "f", "", "file name for the saved file. Use - to output to stdout instead")
 }
 
 // The root command (`qrcp`) is like a shortcut of the `send` command

--- a/cmd/receive.go
+++ b/cmd/receive.go
@@ -24,6 +24,7 @@ func receiveCmdFunc(command *cobra.Command, args []string) error {
 	if err := srv.ReceiveTo(cfg.Output); err != nil {
 		return err
 	}
+
 	// Prints the URL to scan to screen
 	log.Print(`Scan the following URL with a QR reader to start the file transfer, press CTRL+C or "q" to exit:`)
 	log.Print(srv.ReceiveURL)
@@ -31,6 +32,9 @@ func receiveCmdFunc(command *cobra.Command, args []string) error {
 	qr.RenderString(srv.ReceiveURL, cfg.Reversed)
 	if app.Flags.Browser {
 		srv.DisplayQR(srv.ReceiveURL)
+	}
+	if err := srv.FileName(app.Flags.FileName); err != nil {
+		return err
 	}
 	if err := keyboard.Open(); err == nil {
 		defer func() {

--- a/cmd/receive.go
+++ b/cmd/receive.go
@@ -33,7 +33,7 @@ func receiveCmdFunc(command *cobra.Command, args []string) error {
 	if app.Flags.Browser {
 		srv.DisplayQR(srv.ReceiveURL)
 	}
-	if err := srv.FileName(app.Flags.FileName); err != nil {
+	if err := srv.FileName(app.Flags.FileName, app.Flags.OutputDir); err != nil {
 		return err
 	}
 	if err := keyboard.Open(); err == nil {

--- a/config/config.go
+++ b/config/config.go
@@ -92,8 +92,8 @@ func New(app application.App) Config {
 	if app.Flags.FQDN != "" {
 		cfg.FQDN = app.Flags.FQDN
 	}
-	if app.Flags.Output != "" {
-		cfg.Output = app.Flags.Output
+	if app.Flags.OutputDir != "" {
+		cfg.Output = app.Flags.OutputDir
 	}
 	if app.Flags.Reversed {
 		cfg.Reversed = true

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -2,11 +2,20 @@ package logger
 
 import (
 	"fmt"
+	"os"
+
+	"github.com/claudiodangelis/qrcp/util"
 )
 
 // Print prints its argument if the --quiet flag is not passed
 func (l Logger) Print(args ...interface{}) {
-	if !l.quiet {
+	if l.quiet {
+		return
+	}
+
+	if util.OutputIsPipe() {
+		fmt.Fprintln(os.Stderr, args...)
+	} else {
 		fmt.Println(args...)
 	}
 }

--- a/qr/qr.go
+++ b/qr/qr.go
@@ -4,7 +4,9 @@ import (
 	"fmt"
 	"image"
 	"log"
+	"os"
 
+	"github.com/claudiodangelis/qrcp/util"
 	"github.com/skip2/go-qrcode"
 )
 
@@ -14,7 +16,12 @@ func RenderString(s string, inverseColor bool) {
 	if err != nil {
 		log.Fatal(err)
 	}
-	fmt.Println(q.ToSmallString(inverseColor))
+
+	if util.OutputIsPipe() {
+		fmt.Fprintln(os.Stderr, q.ToSmallString(inverseColor))
+	} else {
+		fmt.Println(q.ToSmallString(inverseColor))
+	}
 }
 
 // RenderImage returns a QR code as an image.Image

--- a/server/server.go
+++ b/server/server.go
@@ -62,10 +62,20 @@ func (s *Server) ReceiveTo(dir string) error {
 	return nil
 }
 
-// FileName sets the filename of the received file
-func (s *Server) FileName(name string) error {
+// FileName sets the user-desired filename of the received file
+func (s *Server) FileName(name string, dir string) error {
+	if name == "" {
+		s.fileName = ""
+		return nil
+	}
+
 	if name == "-" {
 		s.fileName = "-"
+		return nil
+	}
+
+	if dir != "" {
+		s.fileName = filepath.Join(dir, name)
 		return nil
 	}
 

--- a/util/util.go
+++ b/util/util.go
@@ -170,3 +170,9 @@ func ReadFilenames(dir string) []string {
 	}
 	return filenames
 }
+
+func OutputIsPipe() bool {
+	fi, _ := os.Stdout.Stat()
+
+	return fi.Mode()&os.ModeCharDevice == 0
+}


### PR DESCRIPTION
When `qrcp` sees that the output is piped, it will now print its messages to stderr instead of stdout, to allow easy piping of output.


```
# saves file with the file path of ./piped_file
./qrcp receive  --file - > piped_file

# sends received data to clipboard manager
./qrcp receive  --file - | $CLIPBOARD_MANAGER
```