### PR TITLE
Add new Android "clone" project to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -419,6 +419,8 @@ Releases are handled with [goreleaser](https://goreleaser.com).
 - [local_file_share](https://github.com/woshimanong1990/local_file_share)  - _"share local file to other people, OR smartphone download files which is in pc"_
 - [qrcp](https://github.com/pearl2201/qrcp) - a desktop app clone of `qrcp`, writing with C# and .NET Core, work for Windows.
 - [swift_file](https://github.com/mateoradman/swift_file) - Rust project inspired by `qrcp`.
+- [qrcp-android](https://github.com/ianfixes/qrcp-android) - Android app inspired by `qrcp`.
+
 ## License
 
 MIT. See [LICENSE](LICENSE).


### PR DESCRIPTION
I love the idea of QRCP, so I built an Android app that allows the same method of sharing -- between phones.