### PR TITLE
docs: fix typo

### DIFF
--- a/docs/tutorials/secure-transfers-with-mkcert.md
+++ b/docs/tutorials/secure-transfers-with-mkcert.md
@@ -124,7 +124,7 @@ Secure transfer:
 qrcp MyDocument.pdf
 ```
 
-Unsecure transfer:
+Insecure transfer:
 ```
 qrcp --secure=false MyDocument.pdf
 ```


### PR DESCRIPTION
Found via `codespell -H -L iif`