### PR TITLE
Fix release download link table

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -44,12 +44,12 @@ changelog:
 release:
   footer: |
     ## Downloads
-    | Platform | Download link                                                                                                                 |
-    |----------|-------------------------------------------------------------------------------------------------------------------------------|
-    | Linux    | [deb package](https://github.com/claudiodangelis/qrcp/releases/download/{{ .Tag }}/qrcp_{{ .Tag }}_linux_x86_64.deb)          |
-    | Linux    | [RPM package](https://github.com/claudiodangelis/qrcp/releases/download/{{ .Tag }}/qrcp_{{ .Tag }}_linux_x86_64.rpm)          |
-    | macOS    | [macOS package](https://github.com/claudiodangelis/qrcp/releases/download/{{ .Tag }}/qrcp_{{ .Tag }}_macOS_x86_64.tar.gz)     |
-    | Windows  | [Windows package](https://github.com/claudiodangelis/qrcp/releases/download/{{ .Tag }}/qrcp_{{ .Tag }}_Windows_x86_64.tar.gz) |
+    | Platform | Download link                                                                                                                |
+    |----------|------------------------------------------------------------------------------------------------------------------------------|
+    | Linux    | [deb package](https://github.com/claudiodangelis/qrcp/releases/download/{{ .Tag }}/qrcp_{{ .Tag }}_linux_amd64.deb)          |
+    | Linux    | [RPM package](https://github.com/claudiodangelis/qrcp/releases/download/{{ .Tag }}/qrcp_{{ .Tag }}_linux_amd64.rpm)          |
+    | macOS    | [macOS package](https://github.com/claudiodangelis/qrcp/releases/download/{{ .Tag }}/qrcp_{{ .Tag }}_darwin_amd64.tar.gz)    |
+    | Windows  | [Windows package](https://github.com/claudiodangelis/qrcp/releases/download/{{ .Tag }}/qrcp_{{ .Tag }}_windows_amd64.tar.gz) |
 
     Refer to the list of assets below for all supported platform.
 nfpms:


### PR DESCRIPTION
links in the github release download link table were 404ing